### PR TITLE
Add Homebrew Configuration/Script

### DIFF
--- a/wasp.rb
+++ b/wasp.rb
@@ -8,5 +8,6 @@ class Wasp < Formula
 
   def install
     bin.install "wasp-bin"
+    mv bin/"wasp-bin", bin/"wasp"
   end
 end

--- a/wasp.rb
+++ b/wasp.rb
@@ -1,0 +1,12 @@
+class Wasp < Formula
+  desc "A programming language that understands what a web app is."
+  homepage "https://wasp-lang.dev/"
+  url "https://github.com/wasp-lang/wasp/releases/download/v0.1.7/wasp-osx-x86_64.tar.gz"
+  version "v0.1.7"
+  sha256 ""
+  license "MIT License"
+
+  def install
+    bin.install "wasp"
+  end
+end

--- a/wasp.rb
+++ b/wasp.rb
@@ -7,6 +7,6 @@ class Wasp < Formula
   license "MIT License"
 
   def install
-    bin.install "wasp"
+    bin.install "wasp-bin"
   end
 end


### PR DESCRIPTION
Hello,
I have added a script for installation of wasp which would normally work by invoking two following commands in terminal:

```shell script
brew tap wasp-lang/wasp
brew install wasp

wasp --help # Test if the binary has been successfully installed.
```

Feel free to update the README.md and the docs if needed (so the users can use these commands instead for MacOS)